### PR TITLE
Asynchronous handling of stdout and stderr

### DIFF
--- a/src/main/java/org/nmap4j/INmap4j.java
+++ b/src/main/java/org/nmap4j/INmap4j.java
@@ -1,0 +1,17 @@
+package org.nmap4j;
+
+import org.nmap4j.core.nmap.ExecutionResults;
+import org.nmap4j.core.nmap.NMapExecutionException;
+import org.nmap4j.core.nmap.NMapInitializationException;
+import org.nmap4j.data.NMapRun;
+
+public interface INmap4j {
+	void execute() throws NMapInitializationException, NMapExecutionException;
+	void addFlags(String flagSet);
+	void includeHosts(String hosts);
+	void excludeHosts(String hosts);
+	String getOutput();
+	NMapRun getResult();
+	boolean hasError();
+	ExecutionResults getExecutionResults();
+}

--- a/src/main/java/org/nmap4j/Nmap4j.java
+++ b/src/main/java/org/nmap4j/Nmap4j.java
@@ -35,7 +35,7 @@ import org.nmap4j.parser.OnePassParser;
  * @author jsvede
  *
  */
-public class Nmap4j {
+public class Nmap4j implements INmap4j {
 	
 	private NMapProperties nmapProperties ;
 	private ArgumentProperties flags ;

--- a/src/main/java/org/nmap4j/core/nmap/NMapProperties.java
+++ b/src/main/java/org/nmap4j/core/nmap/NMapProperties.java
@@ -66,9 +66,6 @@ public class NMapProperties {
   private final String SHARE = "share" ;
   private final String COMMAND = "nmap" ;
   
-  private String sudoUser ;
-  private String sudoUserPassword ;
-   
   /**
    * Constructs an instance of NMapProperties and looks in the environment
    * properties for NMAP_HOME.  If it is not found, the path is initialized


### PR DESCRIPTION
When executed on Windows systems, reading from stdout  and stderr created a deadlock if the output from nmap was larger than the buffer size. Fixed this by reading outputs in different threads and returning the results as CompletableFuture.

Also added the interface INmap4j to make it easier to mock/fake an object in unit tests when using this library.