### PR TITLE
Multiple Hostname Entries

### DIFF
--- a/src/main/java/org/nmap4j/data/nmaprun/Host.java
+++ b/src/main/java/org/nmap4j/data/nmaprun/Host.java
@@ -48,6 +48,7 @@ import org.nmap4j.data.host.TcpTsSequence;
 import org.nmap4j.data.host.Times;
 import org.nmap4j.data.host.Uptime;
 import org.nmap4j.data.host.trace.Trace;
+import org.nmap4j.data.nmaprun.hostnames.Hostname;
 
 
 public class Host {

--- a/src/main/java/org/nmap4j/parser/NMapXmlHandler.java
+++ b/src/main/java/org/nmap4j/parser/NMapXmlHandler.java
@@ -192,12 +192,11 @@ public class NMapXmlHandler extends DefaultHandler {
 			host.addAddress( address ) ;
 		}
 		if( qName.equals( Hostnames.HOSTNAMES_TAG ) ) {
-			hostnames = runHandler.createHostnames( attributes ) ;
-			host.setHostnames( hostnames ) ;
+			host.setHostnames( new ArrayList<>() ) ;
 		}
 		if( qName.equals( Hostname.HOSTNAME_TAG ) ) {
 			hostname = runHandler.createHostname( attributes ) ;
-			hostnames.setHostname( hostname ) ;
+			host.addHostname(hostname);
 		}
 		if( qName.equals( Ports.PORTS_TAG ) ) {
 			ports = runHandler.createPorts(attributes ) ;


### PR DESCRIPTION
While using this awesome library, I found out that we were losing data under the <Hostnames><Hostname> tags. The current version only stores the last Hostname entry under the Hostnames tag. If Nmap returns multiple Hostname entries for a given host, we lose all but the last Hostname. I'm proposing a similar construct to the Host.addresses where we store all Hostname objects in an ArrayList so we don't lose that data.

Thanks!